### PR TITLE
feat - Extract data for SSR from template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Sidewind** is a light (~7k minified) state management solution designed to work together with utility CSS based frameworks, such as [Tailwind.css](https://tailwindcss.com).
+**Sidewind** is a light (~8k minified) state management solution designed to work together with utility CSS based frameworks, such as [Tailwind.css](https://tailwindcss.com).
 
 Sidewind was designed small sites and applications in mind. It allows you to sprinkle state where you need it right in the HTML structure.
 

--- a/documentation/iteration.md
+++ b/documentation/iteration.md
@@ -389,27 +389,3 @@ It's possible to render lists inside lists.
   </div>
 </div>
 ```
-
-## Server-side rendering
-
-`x-each` supports server-side rendering (SSR) out of the box (better SEO without JS enabled). In this case, you should take care to populate the state and adjacent elements with the same state (here different content is used for the sake of testing). The elements marked with `x-template` will be removed when `x-each` mounts and it will use the first one as the template.
-
-```html
-<div
-  x-state="{
-    todos: [
-      { text: 'Wash dishes' }, { text: 'Eat carrots' }
-    ]
-  }"
->
-  <div class="mb-2">
-    <ul class="list-disc list-inside" x-each="state.todos">
-      <li x-template x="state.value.text">Wash dishes (SSR)</li>
-      <li x-template x="state.value.text">Eat carrots (SSR)</li>
-    </ul>
-  </div>
-  <div x="JSON.stringify(state.todos, null, 2)"></div>
-</div>
-```
-
-The example above would work even if you remove the latter `x="state.value.text"` but it can be easier to generate the full form from a site generator.

--- a/documentation/ssr.md
+++ b/documentation/ssr.md
@@ -7,28 +7,25 @@ slug: "ssr"
 `x-each` supports SSR out of the box (better SEO without JS enabled) and it is able to hydrate its state from the rendered markup if `x-ssr` is set.
 
 ```html
-<div x-state="{ todos: [] }">
-  <div class="mb-2">
-    <ul class="list-disc list-inside" x-each="state.todos" x-ssr>
-      <li x-template>
-        <div>
-          <span x="state.value.text">Wash dishes</span>
-        </div>
-        <ul x-each="state.value.tags">
-          <li x-template x="state.value">chore</li>
-        </ul>
-      </li>
-      <li x-template>
-        <div>
-          <span x="state.value.text">Eat vegetables</span>
-        </div>
-        <ul x-each="state.value.tags">
-          <li x-template x="state.value">green</li>
-          <li x-template x="state.value">food</li>
-        </ul>
-      </li>
-    </ul>
-  </div>
-  <div x="JSON.stringify(state.todos, null, 2)"></div>
+<div class="mb-2">
+  <ul class="list-disc list-inside" x-each="state.todos" x-ssr>
+    <li x-template>
+      <span x="state.value.text">Wash dishes</span>
+      <ul x-each="state.value.tags">
+        <li x-template x="state.value">chore</li>
+      </ul>
+      <span x="JSON.stringify(state.value)"></span>
+    </li>
+    <li x-template>
+      <span x="state.value.text">Eat vegetables</span>
+      <ul x-each="state.value.tags">
+        <li x-template x="state.value">green</li>
+        <li x-template x="state.value">food</li>
+      </ul>
+      <span x="JSON.stringify(state.value)"></span>
+    </li>
+  </ul>
 </div>
 ```
+
+> TODO: Add manipulations to test that the state is correct

--- a/documentation/ssr.md
+++ b/documentation/ssr.md
@@ -4,7 +4,9 @@ slug: "ssr"
 
 # Server-side rendering (SSR)
 
-`x-each` supports SSR out of the box (better SEO without JS enabled) and it is able to hydrate its state from the rendered markup if `x-ssr` is set.
+`x-each` supports SSR out of the box (better SEO without JS enabled) and it is able to hydrate its state from the rendered markup if `x-ssr` is set at the boundary.
+
+Note that this doesn't work with complex expressions for now and only direct value lookup is supported as it's possible to figure out object keys and values based on that. It's also limited to a single level of `x-each`.
 
 ```html
 <div x-state="{ todos: [] }">

--- a/documentation/ssr.md
+++ b/documentation/ssr.md
@@ -7,24 +7,27 @@ slug: "ssr"
 `x-each` supports SSR out of the box (better SEO without JS enabled) and it is able to hydrate its state from the rendered markup if `x-ssr` is set.
 
 ```html
-<div class="mb-2">
-  <ul class="list-disc list-inside" x-each="state.todos" x-ssr>
-    <li x-template>
-      <span x="state.value.text">Wash dishes</span>
-      <ul x-each="state.value.tags">
-        <li x-template x="state.value">chore</li>
-      </ul>
-      <span x="JSON.stringify(state.value)"></span>
-    </li>
-    <li x-template>
-      <span x="state.value.text">Eat vegetables</span>
-      <ul x-each="state.value.tags">
-        <li x-template x="state.value">green</li>
-        <li x-template x="state.value">food</li>
-      </ul>
-      <span x="JSON.stringify(state.value)"></span>
-    </li>
-  </ul>
+<div x-state="{ todos: [] }">
+  <div class="mb-2">
+    <ul class="list-disc list-inside" x-each="state.todos" x-ssr>
+      <li x-template>
+        <span x="state.value.text">Wash dishes</span>
+        <ul x-each="state.value.tags">
+          <li x-template x="state.value">chore</li>
+        </ul>
+        <span x="JSON.stringify(state.value)"></span>
+      </li>
+      <li x-template>
+        <span x="state.value.text">Eat vegetables</span>
+        <ul x-each="state.value.tags">
+          <li x-template x="state.value">green</li>
+          <li x-template x="state.value">food</li>
+        </ul>
+        <span x="JSON.stringify(state.value)"></span>
+      </li>
+    </ul>
+  </div>
+  <div x="JSON.stringify(state.todos, null, 2)"></div>
 </div>
 ```
 

--- a/documentation/ssr.md
+++ b/documentation/ssr.md
@@ -12,14 +12,14 @@ slug: "ssr"
     <ul class="list-disc list-inside" x-each="state.todos" x-ssr>
       <li x-template>
         <span x="state.value.text">Wash dishes</span>
-        <ul x-each="state.value.tags">
+        <ul class="list-decimal list-inside ml-2" x-each="state.value.tags">
           <li x-template x="state.value">chore</li>
         </ul>
         <span x="JSON.stringify(state.value)"></span>
       </li>
       <li x-template>
         <span x="state.value.text">Eat vegetables</span>
-        <ul x-each="state.value.tags">
+        <ul class="list-decimal list-inside ml-2" x-each="state.value.tags">
           <li x-template x="state.value">green</li>
           <li x-template x="state.value">food</li>
         </ul>

--- a/documentation/ssr.md
+++ b/documentation/ssr.md
@@ -6,7 +6,7 @@ slug: "ssr"
 
 `x-each` supports SSR out of the box (better SEO without JS enabled) and it is able to hydrate its state from the rendered markup if `x-ssr` is set at the boundary.
 
-Note that this doesn't work with complex expressions for now and only direct value lookup is supported as it's possible to figure out object keys and values based on that. It's also limited to a single level of `x-each`.
+Note that this doesn't work with complex expressions for now and only direct value lookup is supported as it's possible to figure out object keys and values based on that. Also template groups aren't supported yet.
 
 ```html
 <div x-state="{ todos: [] }">
@@ -17,7 +17,6 @@ Note that this doesn't work with complex expressions for now and only direct val
         <ul class="list-decimal list-inside ml-2" x-each="state.value.tags">
           <li x-template x="state.value">chore</li>
         </ul>
-        <span x="JSON.stringify(state.value)"></span>
       </li>
       <li x-template>
         <span x="state.value.text">Eat vegetables</span>
@@ -25,12 +24,9 @@ Note that this doesn't work with complex expressions for now and only direct val
           <li x-template x="state.value">green</li>
           <li x-template x="state.value">food</li>
         </ul>
-        <span x="JSON.stringify(state.value)"></span>
       </li>
     </ul>
   </div>
   <div x="JSON.stringify(state.todos, null, 2)"></div>
 </div>
 ```
-
-> TODO: Add manipulations to test that the state is correct

--- a/documentation/ssr.md
+++ b/documentation/ssr.md
@@ -4,12 +4,12 @@ slug: "ssr"
 
 # Server-side rendering (SSR)
 
-`x-each` supports SSR out of the box (better SEO without JS enabled) and it is able to hydrate its state from the rendered markup.
+`x-each` supports SSR out of the box (better SEO without JS enabled) and it is able to hydrate its state from the rendered markup if `x-ssr` is set.
 
 ```html
 <div x-state="{ todos: [] }">
   <div class="mb-2">
-    <ul class="list-disc list-inside" x-each="state.todos">
+    <ul class="list-disc list-inside" x-each="state.todos" x-ssr>
       <li x-template>
         <div>
           <span x="state.value.text">Wash dishes</span>

--- a/documentation/ssr.md
+++ b/documentation/ssr.md
@@ -4,24 +4,31 @@ slug: "ssr"
 
 # Server-side rendering (SSR)
 
-`x-each` supports SSR out of the box (better SEO without JS enabled). In this case, you should take care to populate the state and adjacent elements with the same state (here different content is used for the sake of testing). The elements marked with `x-template` will be removed when `x-each` mounts and it will use the first one as the template.
+`x-each` supports SSR out of the box (better SEO without JS enabled) and it is able to hydrate its state from the rendered markup.
 
 ```html
-<div
-  x-state="{
-    todos: [
-      { text: 'Wash dishes' }, { text: 'Eat carrots' }
-    ]
-  }"
->
+<div x-state="{ todos: [] }">
   <div class="mb-2">
     <ul class="list-disc list-inside" x-each="state.todos">
-      <li x-template x="state.value.text">Wash dishes (SSR)</li>
-      <li x-template x="state.value.text">Eat carrots (SSR)</li>
+      <li x-template>
+        <div>
+          <span x="state.value.text">Wash dishes</span>
+        </div>
+        <ul x-each="state.value.tags">
+          <li x-template x="state.value">chore</li>
+        </ul>
+      </li>
+      <li x-template>
+        <div>
+          <span x="state.value.text">Eat vegetables</span>
+        </div>
+        <ul x-each="state.value.tags">
+          <li x-template x="state.value">green</li>
+          <li x-template x="state.value">food</li>
+        </ul>
+      </li>
     </ul>
   </div>
   <div x="JSON.stringify(state.todos, null, 2)"></div>
 </div>
 ```
-
-The example above would work even if you remove the latter `x="state.value.text"` but it can be easier to generate the full form from a site generator.

--- a/documentation/ssr.md
+++ b/documentation/ssr.md
@@ -1,0 +1,27 @@
+---
+slug: "ssr"
+---
+
+# Server-side rendering (SSR)
+
+`x-each` supports SSR out of the box (better SEO without JS enabled). In this case, you should take care to populate the state and adjacent elements with the same state (here different content is used for the sake of testing). The elements marked with `x-template` will be removed when `x-each` mounts and it will use the first one as the template.
+
+```html
+<div
+  x-state="{
+    todos: [
+      { text: 'Wash dishes' }, { text: 'Eat carrots' }
+    ]
+  }"
+>
+  <div class="mb-2">
+    <ul class="list-disc list-inside" x-each="state.todos">
+      <li x-template x="state.value.text">Wash dishes (SSR)</li>
+      <li x-template x="state.value.text">Eat carrots (SSR)</li>
+    </ul>
+  </div>
+  <div x="JSON.stringify(state.todos, null, 2)"></div>
+</div>
+```
+
+The example above would work even if you remove the latter `x="state.value.text"` but it can be easier to generate the full form from a site generator.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sidewind",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sidewind",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Sidewind - Tailwind but for state",
   "main": "dist/sidewind.umd.development.js",
   "typings": "dist/index.d.ts",

--- a/site/components/Navigation.json
+++ b/site/components/Navigation.json
@@ -43,6 +43,13 @@
   },
   {
     "element": "Link",
+    "children": "SSR",
+    "attributes": {
+      "href": "/ssr/"
+    }
+  },
+  {
+    "element": "Link",
     "children": "Examples",
     "attributes": {
       "href": "/examples/"

--- a/src/directives/each.ts
+++ b/src/directives/each.ts
@@ -130,8 +130,18 @@ function eachDirective({
           }
         }
 
+        // TODO: Handle x-each
+
         element.state.push(newState);
       }
+
+      // Find the closest state container and update its internal state
+      const parentStateElement = element.closest("[x-state]");
+      const parentKey = expression.split("state.")[1];
+      parentStateElement.state = {
+        ...parentStateElement.state,
+        [parentKey]: element.state,
+      };
     } else {
       // Empty contents as they'll be replaced by applying the template
       while (element.firstChild) {

--- a/src/directives/each.ts
+++ b/src/directives/each.ts
@@ -120,11 +120,13 @@ function eachDirective({
           const xValue = xValues[j];
 
           // Pick only elements without an x-each parent (i.e. the current x-each)
-          if (getParents(xValue, "x-each")[0] === undefined) {
+          if (xValue.closest("[x-each]") === element) {
             const k = xValue.getAttribute("x").split("state.value.")[1];
             const v = xValue.textContent;
 
-            newState[k] = v;
+            if (k) {
+              newState[k] = v;
+            }
           }
         }
 

--- a/src/directives/each.ts
+++ b/src/directives/each.ts
@@ -82,7 +82,8 @@ function eachDirective({
     // In case state is derived from another x-each, use getState(element) here.
     element.state = hasParentEach ? elementState.state : state;
 
-    let templates = element.querySelectorAll(":scope > *[x-template]");
+    const xTemplates = element.querySelectorAll(":scope > *[x-template]");
+    let templates = xTemplates;
 
     if (!templates.length) {
       console.error("x-each - x-template was not found", element);
@@ -108,9 +109,14 @@ function eachDirective({
       element.lastChild && element.removeChild(element.lastChild);
     }
 
-    const renderTemplate = getTemplateRenderer(element, templates, level);
+    if (element.hasAttribute("x-ssr")) {
+      // TODO: Capture state now
+      console.log("capture state");
+    } else {
+      const renderTemplate = getTemplateRenderer(element, templates, level);
 
-    state.forEach(renderTemplate);
+      state.forEach(renderTemplate);
+    }
   }
 
   evaluateDirectives(directives, element);

--- a/src/directives/each.ts
+++ b/src/directives/each.ts
@@ -113,23 +113,7 @@ function eachDirective({
 
       for (let i = 0; i < xTemplates.length; i++) {
         const xTemplate = xTemplates[i];
-        const xValues = xTemplate.querySelectorAll("[x]");
-        const newState: Record<string, unknown> = {};
-
-        for (let j = 0; j < xValues.length; j++) {
-          const xValue = xValues[j];
-
-          // Pick only elements that have the x-each as their parent
-          if (xValue.closest("[x-each]") === element) {
-            const k = xValue.getAttribute("x").split("state.value.")[1];
-            const v = xValue.textContent;
-
-            if (k) {
-              newState[k] = v;
-            }
-          }
-        }
-
+        const newState = getValues(element, xTemplate);
         const xEachContainers = xTemplate.querySelectorAll("[x-each]");
 
         for (let j = 0; j < xEachContainers.length; j++) {
@@ -180,6 +164,30 @@ function eachDirective({
   evaluateDirectives(directives, element);
 }
 eachDirective.evaluateFrom = "top";
+
+function getValues(
+  element: ExtendedHTMLElement,
+  xTemplate: ExtendedHTMLElement
+) {
+  const xValues = xTemplate.querySelectorAll("[x]");
+  const newState: Record<string, unknown> = {};
+
+  for (let j = 0; j < xValues.length; j++) {
+    const xValue = xValues[j];
+
+    // Pick only elements that have the x-each as their parent
+    if (xValue.closest("[x-each]") === element) {
+      const k = xValue.getAttribute("x").split("state.value.")[1];
+      const v = xValue.textContent;
+
+      if (k) {
+        newState[k] = v;
+      }
+    }
+  }
+
+  return newState;
+}
 
 function getTemplateRenderer(
   element: ExtendedHTMLElement,

--- a/src/directives/each.ts
+++ b/src/directives/each.ts
@@ -113,13 +113,13 @@ function eachDirective({
 
       for (let i = 0; i < xTemplates.length; i++) {
         const xTemplate = xTemplates[i];
-        const xValues = xTemplate.querySelectorAll(`[x]`);
+        const xValues = xTemplate.querySelectorAll("[x]");
         const newState: Record<string, unknown> = {};
 
         for (let j = 0; j < xValues.length; j++) {
           const xValue = xValues[j];
 
-          // Pick only elements without an x-each parent (i.e. the current x-each)
+          // Pick only elements that have the x-each as their parent
           if (xValue.closest("[x-each]") === element) {
             const k = xValue.getAttribute("x").split("state.value.")[1];
             const v = xValue.textContent;
@@ -130,7 +130,30 @@ function eachDirective({
           }
         }
 
-        // TODO: Handle x-each
+        const xEachContainers = xTemplate.querySelectorAll("[x-each]");
+
+        for (let j = 0; j < xEachContainers.length; j++) {
+          const xEachContainer = xEachContainers[j];
+
+          // Pick only elements that have the x-each as their parent.
+          // The gotcha here is that since the element itself is x-each,
+          // closest() matches to itself so you should traverse starting from
+          // the immediate parent.
+          if (xEachContainer.parentElement.closest("[x-each]") === element) {
+            const k = xEachContainer
+              .getAttribute("x-each")
+              .split("state.value.")[1];
+
+            // TODO: Get values
+            console.log("found valid x-each", k);
+
+            if (k) {
+              newState[k] = [];
+            }
+          }
+        }
+
+        console.log("x-each containers", xEachContainers);
 
         element.state.push(newState);
       }


### PR DESCRIPTION
This avoids having to generate double data in `x-each` with the cost of a bit of additional code.