### PR TITLE
fix(x-each): Fix rendering of mutated entries + separate x-ssr

### DIFF
--- a/src/directives/each.ts
+++ b/src/directives/each.ts
@@ -1,4 +1,4 @@
-import getParents from "../get-parents";
+import { getLevel, getTemplates } from "../utils";
 import type { DirectiveParameters, ExtendedHTMLElement } from "../types";
 
 function eachDirective({
@@ -10,7 +10,7 @@ function eachDirective({
   directives,
 }: DirectiveParameters) {
   const elementState = getState(element);
-  let state = evaluate(expression, elementState) || [];
+  const state = evaluate(expression, elementState) || [];
 
   if (!Array.isArray(state)) {
     console.error(
@@ -26,9 +26,7 @@ function eachDirective({
     return;
   }
 
-  const level =
-    getParents(element, "x-recurse").length +
-    (element.hasAttribute("x-recurse") ? 1 : 0);
+  const level = getLevel(element);
   const amountOfTemplates = element.templates?.length || 0;
 
   if (amountOfTemplates > 0) {
@@ -84,8 +82,7 @@ function eachDirective({
     // In case state is derived from another x-each, use getState(element) here.
     element.state = hasParentEach ? elementState.state : state;
 
-    const xTemplates = getTemplates(element);
-    let templates = xTemplates;
+    let templates = getTemplates(element);
 
     if (!templates.length) {
       console.error("x-each - x-template was not found", element);
@@ -106,27 +103,6 @@ function eachDirective({
     element.setAttribute("_x-init", "1");
     element.setAttribute("x-has-each", "");
 
-    if (element.hasAttribute("x-ssr")) {
-      element.state = extractValuesFromTemplates(element, xTemplates, level);
-
-      // Find the closest state container and update its internal state
-      const parentStateElement: ExtendedHTMLElement | null =
-        element.closest("[x-state]");
-      if (parentStateElement) {
-        const parentKey = expression.split("state.")[1];
-        parentStateElement.state = {
-          ...parentStateElement.state,
-          [parentKey]: element.state,
-        };
-      }
-
-      // Now that the state has been captured, go back to normal flow
-      element.removeAttribute("x-ssr");
-
-      // Use the state now
-      state = element.state;
-    }
-
     // Empty contents as they'll be replaced by applying the template
     while (element.firstChild) {
       element.lastChild && element.removeChild(element.lastChild);
@@ -140,102 +116,6 @@ function eachDirective({
   evaluateDirectives(directives, element);
 }
 eachDirective.evaluateFrom = "top";
-
-function getTemplates(element: ExtendedHTMLElement) {
-  return element.querySelectorAll(":scope > *[x-template]");
-}
-
-function extractValuesFromTemplates(
-  element: ExtendedHTMLElement,
-  xTemplates: ExtendedHTMLElement["templates"],
-  level: number
-) {
-  const ret = [];
-
-  if (!xTemplates) {
-    return [];
-  }
-
-  for (let i = 0; i < xTemplates.length; i++) {
-    const xTemplate = xTemplates[i] as ExtendedHTMLElement;
-    const newState = getValues(element, xTemplate);
-    const xEachContainers = xTemplate.querySelectorAll("[x-each]");
-
-    // The element should be a state container itself so that children can
-    // access its data.
-    xTemplate.setAttribute("x-state", "");
-
-    for (let j = 0; j < xEachContainers.length; j++) {
-      const xEachContainer = xEachContainers[j] as ExtendedHTMLElement;
-
-      // Pick only elements that have the x-each as their parent.
-      // The gotcha here is that since the element itself is x-each,
-      // closest() matches to itself so you should traverse starting from
-      // the immediate parent.
-      if (xEachContainer.parentElement?.closest("[x-each]") === element) {
-        const xEachValue = xEachContainer.getAttribute("x-each") || "";
-        const k = xEachValue.split("state.value.")[1];
-
-        const v = extractValuesFromTemplates(
-          xEachContainer,
-          getTemplates(xEachContainer),
-          level + 1
-        );
-
-        if (k) {
-          // TODO: Can unpacking be avoided for arrays?
-          if (Array.isArray(v)) {
-            // @ts-ignore How to type this?
-            newState[k] = v.map((i) => i[0]);
-          } else {
-            // @ts-ignore How to type this?
-            newState[k] = v;
-          }
-
-          // The actual state is stored to the object
-          xTemplate.state = { value: v, level };
-        }
-      }
-    }
-
-    ret.push(newState);
-  }
-
-  return ret;
-}
-
-function getValues(
-  element: ExtendedHTMLElement,
-  xTemplate: ExtendedHTMLElement
-) {
-  const xValues = xTemplate.hasAttribute("x")
-    ? [xTemplate]
-    : xTemplate.querySelectorAll("[x]");
-  const newObjectState: Record<string, unknown> = {};
-  const newArrayState = [];
-
-  for (let j = 0; j < xValues.length; j++) {
-    const xValue = xValues[j];
-
-    // Pick only elements that have the x-each as their parent
-    if (xValue.closest("[x-each]") === element) {
-      const xProperty = xValue.getAttribute("x") || "";
-      const v = xValue.textContent;
-
-      if (xProperty === "state.value") {
-        newArrayState.push(v);
-      } else {
-        const k = xProperty.split("state.value.")[1];
-
-        if (k) {
-          newObjectState[k] = v;
-        }
-      }
-    }
-  }
-
-  return newArrayState.length > 0 ? newArrayState : newObjectState;
-}
 
 function getTemplateRenderer(
   element: ExtendedHTMLElement,

--- a/src/directives/each.ts
+++ b/src/directives/each.ts
@@ -60,16 +60,15 @@ function eachDirective({
 
     // Create missing nodes
     if (amountOfExtraNodes > 0) {
-      for (let i = 0; i < amountOfExtraNodes / amountOfTemplates; i++) {
-        const renderTemplate = getTemplateRenderer(
-          element,
-          element.templates,
-          level
-        );
+      const renderTemplate = getTemplateRenderer(
+        element,
+        element.templates,
+        level
+      );
+      const missingState = state.slice(amountOfChildren / amountOfTemplates);
 
-        state
-          .slice(amountOfChildren / amountOfTemplates)
-          .forEach(renderTemplate);
+      for (let i = 0; i < amountOfExtraNodes / amountOfTemplates; i++) {
+        renderTemplate(missingState[i]);
       }
     }
 

--- a/src/directives/index.ts
+++ b/src/directives/index.ts
@@ -6,5 +6,6 @@ export { default as intersectDirective } from "./intersect";
 export { default as intervalDirective } from "./interval";
 export { default as recurseDirective } from "./recurse";
 export { default as promiseDirective } from "./promise";
+export { default as ssrDirective } from "./ssr";
 export { default as stateDirective } from "./state";
 export { default as valueDirective } from "./value";

--- a/src/directives/ssr.ts
+++ b/src/directives/ssr.ts
@@ -14,6 +14,13 @@ function ssrDirective({ element }: DirectiveParameters) {
 
   if (parentStateElement) {
     const expression = element.getAttribute("x-each");
+
+    if (!expression) {
+      console.error("x-ssr - adjacent x-each was not found");
+
+      return;
+    }
+
     const parentKey = expression.split("state.")[1];
 
     parentStateElement.state = {

--- a/src/directives/ssr.ts
+++ b/src/directives/ssr.ts
@@ -1,0 +1,122 @@
+import { getLevel, getTemplates } from "../utils";
+import type { DirectiveParameters, ExtendedHTMLElement } from "../types";
+
+function ssrDirective({ element }: DirectiveParameters) {
+  element.state = extractValuesFromTemplates(
+    element,
+    getTemplates(element),
+    getLevel(element)
+  );
+
+  // Find the closest state container and update its internal state
+  const parentStateElement: ExtendedHTMLElement | null =
+    element.closest("[x-state]");
+
+  if (parentStateElement) {
+    const expression = element.getAttribute("x-each");
+    const parentKey = expression.split("state.")[1];
+
+    parentStateElement.state = {
+      ...parentStateElement.state,
+      [parentKey]: element.state,
+    };
+  }
+
+  // Now that the state has been captured, go back to normal flow
+  element.removeAttribute("x-ssr");
+}
+ssrDirective.evaluateFrom = "top";
+
+function extractValuesFromTemplates(
+  element: ExtendedHTMLElement,
+  xTemplates: ExtendedHTMLElement["templates"],
+  level: number
+) {
+  const ret = [];
+
+  if (!xTemplates) {
+    return [];
+  }
+
+  for (let i = 0; i < xTemplates.length; i++) {
+    const xTemplate = xTemplates[i] as ExtendedHTMLElement;
+    const newState = getValues(element, xTemplate);
+    const xEachContainers = xTemplate.querySelectorAll("[x-each]");
+
+    // The element should be a state container itself so that children can
+    // access its data.
+    xTemplate.setAttribute("x-state", "");
+
+    for (let j = 0; j < xEachContainers.length; j++) {
+      const xEachContainer = xEachContainers[j] as ExtendedHTMLElement;
+
+      // Pick only elements that have the x-each as their parent.
+      // The gotcha here is that since the element itself is x-each,
+      // closest() matches to itself so you should traverse starting from
+      // the immediate parent.
+      if (xEachContainer.parentElement?.closest("[x-each]") === element) {
+        const xEachValue = xEachContainer.getAttribute("x-each") || "";
+        const k = xEachValue.split("state.value.")[1];
+
+        const v = extractValuesFromTemplates(
+          xEachContainer,
+          getTemplates(xEachContainer),
+          level + 1
+        );
+
+        if (k) {
+          // TODO: Can unpacking be avoided for arrays?
+          if (Array.isArray(v)) {
+            // @ts-ignore How to type this?
+            newState[k] = v.map((i) => i[0]);
+          } else {
+            // @ts-ignore How to type this?
+            newState[k] = v;
+          }
+
+          // The actual state is stored to the object
+          xTemplate.state = { value: v, level };
+        }
+      }
+    }
+
+    ret.push(newState);
+  }
+
+  return ret;
+}
+
+function getValues(
+  element: ExtendedHTMLElement,
+  xTemplate: ExtendedHTMLElement
+) {
+  const xValues = xTemplate.hasAttribute("x")
+    ? [xTemplate]
+    : xTemplate.querySelectorAll("[x]");
+  const newObjectState: Record<string, unknown> = {};
+  const newArrayState = [];
+
+  for (let j = 0; j < xValues.length; j++) {
+    const xValue = xValues[j];
+
+    // Pick only elements that have the x-each as their parent
+    if (xValue.closest("[x-each]") === element) {
+      const xProperty = xValue.getAttribute("x") || "";
+      const v = xValue.textContent;
+
+      if (xProperty === "state.value") {
+        newArrayState.push(v);
+      } else {
+        const k = xProperty.split("state.value.")[1];
+
+        if (k) {
+          newObjectState[k] = v;
+        }
+      }
+    }
+  }
+
+  return newArrayState.length > 0 ? newArrayState : newObjectState;
+}
+
+export default ssrDirective;

--- a/src/evaluate-directives.ts
+++ b/src/evaluate-directives.ts
@@ -55,8 +55,13 @@ function evaluateDirective(
 
     const closestEach = name !== "x-each" && element.closest("[x-each]");
 
+    // TODO: Simplify this logic somehow
     // If scope isn't ready, skip until a later evaluation
-    if (closestEach && !closestEach.getAttribute("_x-init")) {
+    if (
+      name !== "x-ssr" &&
+      closestEach &&
+      !closestEach.getAttribute("_x-init")
+    ) {
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   intersectDirective,
   recurseDirective,
   promiseDirective,
+  ssrDirective,
   stateDirective,
   valueDirective,
 } from "./directives";
@@ -25,6 +26,7 @@ declare global {
 function evaluateAllDirectives() {
   evaluateDirectives([
     { name: "x-state", directive: stateDirective },
+    { name: "x-ssr", directive: ssrDirective },
     { name: "x-each", directive: eachDirective },
     { name: "x-attr", directive: attributeDirective },
     { name: "x", directive: valueDirective },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { BindState } from "./types";
+import type { BindState, ExtendedHTMLElement } from "./types";
+import getParents from "./get-parents";
 
 function get(object: BindState, keyString: string) {
   const keys = keyString.split(".");
@@ -9,6 +10,17 @@ function get(object: BindState, keyString: string) {
   });
 
   return ret;
+}
+
+function getLevel(element: ExtendedHTMLElement) {
+  return (
+    getParents(element, "x-recurse").length +
+    (element.hasAttribute("x-recurse") ? 1 : 0)
+  );
+}
+
+function getTemplates(element: ExtendedHTMLElement) {
+  return element.querySelectorAll(":scope > *[x-template]");
 }
 
 function getValues(data: BindState, getter: string | null): BindState {
@@ -29,4 +41,4 @@ function getValues(data: BindState, getter: string | null): BindState {
   };
 }
 
-export { get, getValues };
+export { get, getLevel, getTemplates, getValues };


### PR DESCRIPTION
Now `x-ssr` is in a directive of its own so one day it can be loaded optionally.